### PR TITLE
IMU anti alias filter

### DIFF
--- a/lib/IMU/IMU.h
+++ b/lib/IMU/IMU.h
@@ -55,6 +55,8 @@ private:
   void read_latest_accel_raw(int16_t *);
   void read_latest_gyro_raw(int16_t *);
 
+  int write_reg_mask(uint8_t addr, uint8_t mask, uint8_t val);
+
   SPI_Interface spi_interface;
 
   void *inv_icm;


### PR DESCRIPTION
I enabled the imu anti alias filter and set the bandwidth to 997 hz. Also increased the odr from 1 kHz to 2 kHz. Per Pablo's request. This code is untested so we should test before merging.